### PR TITLE
Added missing $entry calls, fixing a Scheduler and UCEH bug

### DIFF
--- a/src/main/java/no/eirikb/gwtchannelapi/client/Channel.java
+++ b/src/main/java/no/eirikb/gwtchannelapi/client/Channel.java
@@ -91,22 +91,22 @@ public class Channel {
         var socket = channel.open();
         var self = this;
 
-        socket.onmessage = function(evt) {
+        socket.onmessage = $entry(function(evt) {
             var data = evt.data;
             self.@no.eirikb.gwtchannelapi.client.Channel::onMessage(Ljava/lang/String;)(data);
-        };
+        });
 
-        socket.onopen = function() {
+        socket.onopen = $entry(function() {
             self.@no.eirikb.gwtchannelapi.client.Channel::onOpen()();
-        };
+        });
 
-        socket.onerror = function(error) {
+        socket.onerror = $entry(function(error) {
             self.@no.eirikb.gwtchannelapi.client.Channel::onError(ILjava/lang/String;)(error.code, error.description);
-        };
+        });
 
-        socket.onclose = function() {
+        socket.onclose = $entry(function() {
             self.@no.eirikb.gwtchannelapi.client.Channel::onClose()();
-        };
+        });
     }-*/;
 
     public void send(String message) {


### PR DESCRIPTION
All calls that come from JS must go through $entry to hook
into GWT's exception handling code and setting up any
future scheduleFinally calls.
